### PR TITLE
Add no-floating-promises rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,22 +1,21 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
-    ],
-    "jsRules": {},
-    "rules": {
-        "quotemark": [true, "single", "avoid-escape"],
-        "object-literal-sort-keys": false,
-        "trailing-comma": false,
-        "arrow-parens": false,
-        "no-var-requires": false,
-        "max-classes-per-file": false,
-        "interface-name":false,
-        "no-empty": [true, "allow-empty-functions"],
-        "ordered-imports": false,
-        "whitespace": [true, "single"],
-        "indent": [true, "spaces", 2],
-        "file-name-casing": [true, { ".tsx": "pascal-case", ".ts": "kebab-case" }]
-    },
-    "rulesDirectory": []
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {
+    "quotemark": [true, "single", "avoid-escape"],
+    "object-literal-sort-keys": false,
+    "trailing-comma": false,
+    "arrow-parens": false,
+    "no-var-requires": false,
+    "max-classes-per-file": false,
+    "interface-name": false,
+    "no-empty": [true, "allow-empty-functions"],
+    "ordered-imports": false,
+    "whitespace": [true, "single"],
+    "indent": [true, "spaces", 2],
+    "file-name-casing": [true, { ".tsx": "pascal-case", ".ts": "kebab-case" }],
+    "no-floating-promises": true
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
I've fixed a few bugs due to missing `await` keywords. I'm setting `no-floating-promises: true` so that you'll now be warned if you're not doing anything with a promise response, by default. This may cause breaking changes to existing builds, so at first I'll see what problems are revealed with this rule enabled.

If you need to override this setting, you can set: 
`// tslint:disable-next-line:no-floating-promises`

[TSLint: No Floating Promises](https://palantir.github.io/tslint/rules/no-floating-promises/)